### PR TITLE
Add manifest categories and visibility

### DIFF
--- a/napari_demo/napari.yaml
+++ b/napari_demo/napari.yaml
@@ -2,6 +2,8 @@ name: napari-demo
 display_name: Demo plugin ported from npe2 example
 on_activate: napari_demo:activate
 on_deactivate: napari_demo:deactivate
+categories: ["Acquisition", "Dataset", "Segmentation"]
+visibility: "hidden"
 contributions:
   commands:
     - id: napari-demo.about


### PR DESCRIPTION
Add example categories to manifest and add `visibility` field to ensure `napari-demo` remains hidden after changes in [napari-hub/#1261](https://github.com/chanzuckerberg/napari-hub/pull/1261) are released.

Note this will require a release of `napari-demo`